### PR TITLE
Add support for supplementary shows not in RadioCult

### DIFF
--- a/data/additional-shows.json
+++ b/data/additional-shows.json
@@ -1,0 +1,91 @@
+{
+  "_comment": "Shows to add that don't exist in RadioCult. Archives can be specified directly or via manual-matches.json using the slug.",
+  "shows": [
+    {
+      "title": "Under A Plastic Cloud",
+      "start": "2025-12-15T10:00:00.000Z",
+      "end": "2025-12-15T12:00:00.000Z",
+      "artistSlug": "phil-hope",
+      "mixcloud": "https://www.mixcloud.com/eistcork/phil-hope-under-a-plastic-cloud-15122025/"
+    },
+    {
+      "title": "Leafy Garments",
+      "start": "2025-12-15T16:00:00.000Z",
+      "end": "2025-12-15T18:00:00.000Z",
+      "artistSlug": "tino",
+      "mixcloud": "https://www.mixcloud.com/eistcork/tino-leafy-garments-episode-11-dec-25/",
+      "episode_info": "Ep. 11"
+    },
+    {
+      "title": "In the Interim w/ Paul Dylan",
+      "start": "2025-12-15T09:00:00.000Z",
+      "end": "2025-12-15T10:00:00.000Z",
+      "artistSlug": "paul-dylan",
+      "soundcloud": "https://soundcloud.com/eistcork/interim-xmas-paul-dylan",
+      "description": "Interim Xmas special"
+    },
+    {
+      "title": "seomra folamh - Danny McCarthy Special",
+      "start": "2025-12-17T12:00:00.000Z",
+      "end": "2025-12-17T14:00:00.000Z",
+      "artistSlug": "phil-maguire",
+      "mixcloud": "https://www.mixcloud.com/eistcork/phil-maguire-seomra-folamh-danny-mccarthy-special-251217/"
+    },
+    {
+      "title": "Radio Dé-coll/Age",
+      "start": "2025-12-17T19:00:00.000Z",
+      "end": "2025-12-17T20:00:00.000Z",
+      "artistSlug": "dave-murphy",
+      "mixcloud": "https://www.mixcloud.com/eistcork/dave-murphy-radio-d%C3%A9-collage-11-171225/",
+      "episode_info": "#11"
+    },
+    {
+      "title": "ATBND 11",
+      "start": "2025-12-19T17:00:00.000Z",
+      "end": "2025-12-19T19:00:00.000Z",
+      "artistSlug": "cack-jollins",
+      "soundcloud": "https://soundcloud.com/eistcork/cack-jollins-atbnd-11-19122025"
+    },
+    {
+      "title": "Nollaig Mar Dhea",
+      "start": "2025-12-20T19:00:00.000Z",
+      "end": "2025-12-20T20:00:00.000Z",
+      "artistSlug": "mike-mcgrath-bryan",
+      "mixcloud": "https://www.mixcloud.com/eistcork/mike-mcgrath-bryan-nollaig-mar-dhea/",
+      "soundcloud": "https://soundcloud.com/eistcork/mike-mcgrath-bryan-nollaig-mar"
+    },
+    {
+      "title": "HIFI hide and seek",
+      "start": "2025-12-20T16:00:00.000Z",
+      "end": "2025-12-20T18:00:00.000Z",
+      "artistSlug": "james-fitzgerald",
+      "mixcloud": "https://www.mixcloud.com/eistcork/hi-fi-hide-and-seek-december-2025/",
+      "soundcloud": "https://soundcloud.com/eistcork/hi-fi-hide-and-seek-december"
+    },
+    {
+      "title": "Land of Some Other",
+      "start": "2025-12-24T16:00:00.000Z",
+      "end": "2025-12-24T17:00:00.000Z",
+      "artistSlug": "christopher-steenson",
+      "mixcloud": "https://www.mixcloud.com/eistcork/christopher-steenson-land-of-some-other-episode-8-christmas-special/",
+      "episode_info": "Ep. 8",
+      "description": "Christmas Special"
+    },
+    {
+      "title": "Wild Freqs",
+      "start": "2025-12-24T11:00:00.000Z",
+      "end": "2025-12-24T12:00:00.000Z",
+      "artistSlug": "michael-lightborne",
+      "mixcloud": "https://www.mixcloud.com/eistcork/michael-lightborne-wild-freqs-winter-solstice-edition/",
+      "description": "Winter Solstice edition"
+    },
+    {
+      "title": "sonic core of new statues",
+      "start": "2025-12-27T18:00:00.000Z",
+      "end": "2025-12-27T20:00:00.000Z",
+      "artistSlug": "japhet-santana",
+      "mixcloud": "https://www.mixcloud.com/eistcork/japhet-santana-sonic-core-of-new-statues-12-27122025/",
+      "episode_info": "#12"
+    }
+  ]
+}

--- a/generate-show-cache.py
+++ b/generate-show-cache.py
@@ -57,6 +57,7 @@ EXTERNAL_ARCHIVES_FILE = DATA_DIR / "external-archives.json"
 CACHE_META_FILE = DATA_DIR / "cache-meta.json"
 REVIEW_QUEUE_FILE = DATA_DIR / "review-queue.json"
 GROUND_TRUTH_FILE = DATA_DIR / "ground-truth-matches.json"
+ADDITIONAL_SHOWS_FILE = DATA_DIR / "additional-shows.json"
 
 # Rate limiting
 REQUEST_DELAY = 0.5  # Seconds between API requests
@@ -200,6 +201,123 @@ def should_exclude_show(show):
             return True
 
     return False
+
+
+def load_additional_shows(artists_by_slug):
+    """Load additional shows from data/additional-shows.json."""
+    if not ADDITIONAL_SHOWS_FILE.exists():
+        return []
+
+    try:
+        data = json.loads(ADDITIONAL_SHOWS_FILE.read_text())
+        additional = []
+
+        for show in data.get('shows', []):
+            # Generate unique ID and slug
+            title = show.get('title', '')
+            start = show.get('start', '')
+
+            if not title or not start:
+                print(f"  Warning: Skipping additional show without title/start")
+                continue
+
+            slug = generate_slug(title, start)
+            show_id = f"additional-{slug}"
+
+            # Look up artist info
+            artist_slug = show.get('artistSlug', '')
+            artist = artists_by_slug.get(artist_slug, {})
+            artist_id = artist.get('id')
+            artist_name = artist.get('name', show.get('artistName', ''))
+
+            additional.append({
+                'id': show_id,
+                'title': title,
+                'slug': slug,
+                'start': start,
+                'end': show.get('end', start),
+                'artistIds': [artist_id] if artist_id else [],
+                'artistName': artist_name,
+                'artistSlug': artist_slug,
+                'description': show.get('description'),
+                # Pre-populate archive URLs if provided
+                '_additional_soundcloud': show.get('soundcloud'),
+                '_additional_mixcloud': show.get('mixcloud'),
+                'episode_info': show.get('episode_info'),
+            })
+
+        if additional:
+            print(f"  Loaded {len(additional)} additional shows")
+
+        return additional
+    except Exception as e:
+        print(f"  Warning: Failed to load additional shows: {e}")
+        return []
+
+
+def apply_additional_show_matches(shows, mixcloud_cache, soundcloud_cache, show_matches):
+    """
+    Apply pre-specified archive URLs from additional shows.
+
+    Additional shows can have _additional_soundcloud and _additional_mixcloud
+    fields with direct URLs to archives. This function matches those URLs
+    against the archive caches and adds them to show_matches.
+    """
+    matched = 0
+
+    for show in shows:
+        show_id = show.get('id', '')
+        if not show_id.startswith('additional-'):
+            continue
+
+        sc_url = show.get('_additional_soundcloud')
+        mc_url = show.get('_additional_mixcloud')
+
+        if not sc_url and not mc_url:
+            continue
+
+        # Ensure show has an entry in show_matches
+        if show_id not in show_matches:
+            show_matches[show_id] = {}
+
+        # Match SoundCloud URL
+        if sc_url:
+            sc_url_clean = sc_url.split('?')[0].rstrip('/')
+            for sc in soundcloud_cache:
+                archive_url = sc.get('url', '').split('?')[0].rstrip('/')
+                if archive_url == sc_url_clean:
+                    show_matches[show_id]['soundcloud'] = {
+                        'id': sc.get('id'),
+                        'title': sc.get('title'),
+                        'url': sc.get('url'),
+                        'duration': sc.get('duration'),
+                        'score': 600,  # High confidence for direct URL match
+                        'match_type': 'additional_show_url'
+                    }
+                    matched += 1
+                    break
+
+        # Match Mixcloud URL
+        if mc_url:
+            mc_url_clean = mc_url.split('?')[0].rstrip('/')
+            for mc in mixcloud_cache:
+                archive_url = mc.get('url', '').split('?')[0].rstrip('/')
+                if mc_url_clean in archive_url or archive_url in mc_url_clean:
+                    show_matches[show_id]['mixcloud'] = {
+                        'name': mc.get('name'),
+                        'slug': mc.get('slug'),
+                        'url': mc.get('url'),
+                        'audio_length': mc.get('audio_length'),
+                        'score': 600,  # High confidence for direct URL match
+                        'match_type': 'additional_show_url'
+                    }
+                    matched += 1
+                    break
+
+    if matched:
+        print(f"  Applied {matched} additional show archive matches")
+
+    return matched
 
 
 def fetch_radiocult_schedule(api_key, start_date, end_date):
@@ -970,6 +1088,11 @@ def main():
     original_shows = [s for s in all_shows if not should_exclude_show(s)]
     print(f"\nAfter filtering: {len(original_shows)} original broadcasts")
 
+    # Load and merge additional shows (shows not in RadioCult)
+    artists_by_slug = {normalize_to_slug(a.get('name', '')): a for a in artists.values()}
+    additional_shows = load_additional_shows(artists_by_slug)
+    original_shows.extend(additional_shows)
+
     # Process upcoming schedule (needs artists data)
     now = datetime.now()
     if upcoming_schedule and 'schedules' in upcoming_schedule:
@@ -1042,6 +1165,9 @@ def main():
             print(f"  New external archives fetched: {len(newly_fetched.get('mixcloud', []))} MC, {len(newly_fetched.get('soundcloud', []))} SC")
             save_external_archives(external_cache, newly_fetched)
 
+        # Apply matches for additional shows with pre-specified URLs
+        apply_additional_show_matches(original_shows, mixcloud_cache, soundcloud_cache, show_matches)
+
         # Load existing review queue
         review_queue = []
         if REVIEW_QUEUE_FILE.exists():
@@ -1069,11 +1195,19 @@ def main():
             print(f"  Saved {len(newly_fetched.get('mixcloud', []))} new external Mixcloud, "
                   f"{len(newly_fetched.get('soundcloud', []))} new external SoundCloud to {EXTERNAL_ARCHIVES_FILE}")
 
+        # Apply matches for additional shows with pre-specified URLs
+        apply_additional_show_matches(original_shows, mixcloud_cache, soundcloud_cache, show_matches)
+
     # Build final output
     # In incremental mode (no new archives), use existing_shows to preserve all fields
     # Otherwise use original_shows (which combines cached + fresh data)
     if new_mixcloud_count == 0 and new_soundcloud_count == 0 and existing_shows and not full_refresh:
         shows_for_output = list(existing_shows.values())
+        # Also include any new additional shows not already in cache
+        existing_ids = set(existing_shows.keys())
+        for show in additional_shows:
+            if show.get('id') not in existing_ids:
+                shows_for_output.append(show)
     else:
         shows_for_output = original_shows
     all_show_data, matched_count = build_show_output(shows_for_output, show_matches, artists)

--- a/generate-show-cache.py
+++ b/generate-show-cache.py
@@ -291,6 +291,7 @@ def apply_additional_show_matches(shows, mixcloud_cache, soundcloud_cache, show_
                         'title': sc.get('title'),
                         'url': sc.get('url'),
                         'duration': sc.get('duration'),
+                        'thumbnail': sc.get('thumbnail'),  # Include artwork
                         'score': 600,  # High confidence for direct URL match
                         'match_type': 'additional_show_url'
                     }
@@ -308,6 +309,7 @@ def apply_additional_show_matches(shows, mixcloud_cache, soundcloud_cache, show_
                         'slug': mc.get('slug'),
                         'url': mc.get('url'),
                         'audio_length': mc.get('audio_length'),
+                        'pictures': mc.get('pictures', {}),  # Include artwork
                         'score': 600,  # High confidence for direct URL match
                         'match_type': 'additional_show_url'
                     }


### PR DESCRIPTION
## Summary

- Adds `additional-shows.json` to inject shows into the archive that exist on Mixcloud/SoundCloud but are missing from RadioCult's schedule data
- Handles gaps in RadioCult data (like the Dec 15-24 2025 outage) and one-off broadcasts not scheduled through RadioCult
- Shows link to existing artists via `artistSlug` and can specify direct archive URLs

## December 2025 Gap Recovery

This PR includes 11 shows recovered from the December 2025 RadioCult data gap:

| Date | Artist | Show |
|------|--------|------|
| Dec 15 | Phil Hope | Under A Plastic Cloud |
| Dec 15 | Tino | Leafy Garments Ep. 11 |
| Dec 15 | Paul Dylan | In the Interim (Xmas) |
| Dec 17 | Phil Maguire | seomra folamh - Danny McCarthy Special |
| Dec 17 | Dave Murphy | Radio Dé-coll/Age #11 |
| Dec 19 | Cack Jollins | ATBND 11 |
| Dec 20 | Mike McGrath-Bryan | Nollaig Mar Dhea |
| Dec 20 | James Fitzgerald | HIFI hide and seek |
| Dec 24 | Christopher Steenson | Land of Some Other Ep. 8 |
| Dec 24 | Michael Lightborne | Wild Freqs (Winter Solstice) |
| Dec 27 | japhet santana | sonic core of new statues #12 |

## Test plan

- [ ] Run `python3 generate-show-cache.py` - should show "Loaded 11 additional shows"
- [ ] Run `python3 generate-show-pages.py` - archive pages should be generated
- [ ] Verify archive pages link correctly to artist pages
- [ ] Check that related shows are populated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)