### PR TITLE
Add manual match for Sound Atlas #3 with Jouko

### DIFF
--- a/data/additional-shows.json
+++ b/data/additional-shows.json
@@ -47,6 +47,14 @@
       "soundcloud": "https://soundcloud.com/eistcork/cack-jollins-atbnd-11-19122025"
     },
     {
+      "title": "Sound Atlas #3 JOUKO",
+      "start": "2025-12-19T22:00:00.000Z",
+      "end": "2025-12-19T23:00:00.000Z",
+      "artistSlug": "jouko",
+      "mixcloud": "https://www.mixcloud.com/eistcork/sound-atlas-3/",
+      "episode_info": "#3"
+    },
+    {
       "title": "Nollaig Mar Dhea",
       "start": "2025-12-20T19:00:00.000Z",
       "end": "2025-12-20T20:00:00.000Z",


### PR DESCRIPTION
## Summary

Links the existing RadioCult show "Sound Atlas #3 JOUKO" (Dec 19, 2025) to its Mixcloud archive via manual-matches.json.

This show existed in RadioCult but wasn't automatically matched to the Mixcloud upload.

## Test plan

- [ ] Verify https://eist.radio/artists/jouko/ shows Sound Atlas #3
- [ ] Verify the archive page has the Mixcloud embed

🤖 Generated with [Claude Code](https://claude.com/claude-code)