### PR TITLE
Front page: Hide "OFFLINE" image showing during page load

### DIFF
--- a/assets/scss/_player.scss
+++ b/assets/scss/_player.scss
@@ -20,6 +20,7 @@
     position: absolute;
     inset: 0;
     z-index: 1;
+    background: $eist;  /* Show brand color while image loads */
 }
 
 .front-hero-image {

--- a/assets/scss/_player.scss
+++ b/assets/scss/_player.scss
@@ -27,6 +27,12 @@
     height: 100%;
     object-fit: cover;
     object-position: center 33%;  /* Adjustable focus point */
+    opacity: 0;
+    transition: opacity 0.3s ease;
+
+    &.loaded {
+        opacity: 1;
+    }
 }
 
 .front-hero-overlay {

--- a/static/js/front-page.js
+++ b/static/js/front-page.js
@@ -124,8 +124,10 @@ function initializeFrontPage() {
         if (showTitleElementFrontPage) showTitleElementFrontPage.textContent = showTitle;
 
         if (artistImageElement) {
-            artistImageElement.src = frontPageArtistDetails.image || defaultOfflineImage;
-            artistImageElement.classList.add('loaded');
+            const newSrc = frontPageArtistDetails.image || defaultOfflineImage;
+            // Only fade in after image has fully loaded
+            artistImageElement.onload = () => artistImageElement.classList.add('loaded');
+            artistImageElement.src = newSrc;
         }
     }
 

--- a/static/js/front-page.js
+++ b/static/js/front-page.js
@@ -123,7 +123,10 @@ function initializeFrontPage() {
         if (showDescElement) showDescElement.innerHTML = showDesc;
         if (showTitleElementFrontPage) showTitleElementFrontPage.textContent = showTitle;
 
-        if (artistImageElement) artistImageElement.src = frontPageArtistDetails.image || defaultOfflineImage;
+        if (artistImageElement) {
+            artistImageElement.src = frontPageArtistDetails.image || defaultOfflineImage;
+            artistImageElement.classList.add('loaded');
+        }
     }
 
     updateFrontPageDetails();


### PR DESCRIPTION
## Summary
On front page on first eist.radio load...
- Hide the hero image initially with `opacity: 0`
- Add `.loaded` class after JS sets the correct image source
- Image fades in smoothly once the API has responded

This prevents the "OFFLINE" diagonal graphic from flashing for a few seconds while the API determines the actual broadcast status.

## Test plan
- [ ] Load the front page and verify no offline graphic flash
- [ ] Confirm image fades in smoothly after API responds
- [ ] Check both online and offline states work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)