### PR TITLE
Update README local build steps and add workflow keepalive

### DIFF
--- a/.github/workflows/re-enable-workflows.yml
+++ b/.github/workflows/re-enable-workflows.yml
@@ -1,0 +1,16 @@
+name: Re-enable workflows
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  re-enable:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          gh workflow enable deploy.yml
+          gh workflow enable preview.yml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -27,25 +27,32 @@ Add `noindex = true` if you don't want the page to be indexed by the Goog.
 
 # Checking your build locally
 
-Get the API key from RadioCult and save it in a `.env` file locally, for example:
+Install Python dependencies:
 
-```cmd
-cat .env
-API_KEY=<REDACTED>
+```bash
+pip3 install thefuzz python-Levenshtein requests
 ```
 
-Then:
+Get the API keys from RadioCult and SoundCloud, and save them in a `.env` file locally:
 
-```cmd
-source .env && export API_KEY SOUNDCLOUD_CLIENT_ID SOUNDCLOUD_CLIENT_SECRET
+```bash
+API_KEY=your_radiocult_key
+SOUNDCLOUD_CLIENT_ID=your_soundcloud_client_id
+SOUNDCLOUD_CLIENT_SECRET=your_soundcloud_client_secret
+```
+
+Then source the `.env` file and run the dev server:
+
+```bash
+if [ -f ~/.env ]; then
+    set -a
+    source ~/.env
+    set +a
+fi
 python3 generate-artist-pages.py
+python3 generate-show-cache.py
+python3 generate-show-pages.py
 hugo server --disableFastRender
-```
-
-On Windows:
-
-```cmd
-set API_KEY=xxxxx
 ```
 
 # Deploying previews with Surge


### PR DESCRIPTION
Fix the "Checking your build locally" section with correct dependencies, env vars, and all required python scripts. Add a monthly workflow to re-enable scheduled workflows that GitHub disables after 60 days of inactivity.